### PR TITLE
docs: automatic yanking using nvim-osc52 and enabling plugin only in SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,18 @@ vim.cmd([[
   augroup END
 ]])
 ```
+
+## Using nvim-osc52 only in SSH
+
+If you want to load this plugin only when connected via SSH, add the following
+`cond` to the Packer configuration for this plugin:
+
+```lua
+use {
+  'ojroques/nvim-osc52',
+  cond = function()
+    local ssh_connection = vim.env.SSH_CONNECTION
+    return ssh_connection ~= nil and ssh_connection ~= ""
+  end,
+}
+```

--- a/README.md
+++ b/README.md
@@ -75,3 +75,25 @@ Note that if you set your clipboard provider like the example above, copying
 text from outside Neovim and pasting with <kbd>p</kbd> won't work. But you can
 still use the paste shortcut of your terminal emulator (usually
 <kbd>ctrl+shift+v</kbd>).
+
+## Automatically yanking using nvim-osc52
+
+Using the `:h TextYankPost` autocommand, you can use nvim-osc52 during whatever
+yank commands.
+
+```lua
+vim.api.nvim_create_user_command("OSCYank", function()
+  local text = vim.fn.getreg("+")
+  require("osc52").copy(text)
+end, {
+  bar = true,
+})
+
+-- NOTE: cannot use Lua API to create the autocmd because it does not support accessing v:event
+vim.cmd([[
+  augroup OSCYank
+    autocmd!
+    autocmd TextYankPost * if v:event.operator is 'y' && v:event.regname is '+' | OSCYank | endif
+  augroup END
+]])
+```


### PR DESCRIPTION
Hey! Thanks for a great plugin. I just spent a few hours trying to debug [vim-oscyank](https://github.com/ojroques/vim-oscyank) using tmux 3.3a and kitty and nvim-osc52 made it finally work :tada: 

I want to contribute some quality-of-life improvements to the suggested configuration. I have been using them for some time and they worked well for me. I hope they are useful to other users of the plugin as well