### PR TITLE
Fix ssh inside tmux by checking TERM

### DIFF
--- a/lua/osc52.lua
+++ b/lua/osc52.lua
@@ -85,7 +85,7 @@ function M.copy(text)
   local text_b64 = base64.enc(text)
   local osc52 = fmt(options.osc52, text_b64)
   local msg = '%d characters copied'
-  if options.tmux_passthrough and os.getenv("TMUX") then
+  if options.tmux_passthrough and os.getenv("TERM"):match("^tmux") then
     osc52 = fmt('\27Ptmux;\27%s\27\\', osc52)
     msg = msg .. ' (tmux passthrough)'
   end


### PR DESCRIPTION
Issue:
If we use ssh inside tmux the TMUX env isn't passed over ssh so we use the wrong osc52 code.
Fix:
if we check the TERM env instead that still works in local TMUX and also in the remote case as well.
Notes:
tested locally and works in both cases.