### PR TITLE
try to match screen from TERM

### DIFF
--- a/lua/osc52.lua
+++ b/lua/osc52.lua
@@ -85,7 +85,7 @@ function M.copy(text)
   local text_b64 = base64.enc(text)
   local osc52 = fmt(options.osc52, text_b64)
   local msg = '%d characters copied'
-  if options.tmux_passthrough and os.getenv("TERM"):match("^tmux") then
+  if options.tmux_passthrough and (os.getenv("TERM"):match("^tmux") or os.getenv("TERM"):match("^screen")) then
     osc52 = fmt('\27Ptmux;\27%s\27\\', osc52)
     msg = msg .. ' (tmux passthrough)'
   end


### PR DESCRIPTION
sometimes tmux sets the TERM env variable to screen, from the [docs](https://man7.org/linux/man-pages/man1/tmux.1.html):
```
       default-terminal terminal
               Set the default terminal for new windows created in this
               session - the default value of the TERM environment
               variable.  For to work correctly, this must be set to
               ‘screen’, ‘tmux’ or a derivative of them.
```