### PR TITLE
Add new function copy_operator

### DIFF
--- a/lua/osc52.lua
+++ b/lua/osc52.lua
@@ -131,6 +131,10 @@ function M.copy_register(register)
   return M.copy(text)
 end
 
+function M.copy_operator_text(text)
+	return M.copy(text)
+end
+
 -------------------- SETUP ---------------------------------
 function M.setup(user_options)
   if user_options then

--- a/lua/osc52.lua
+++ b/lua/osc52.lua
@@ -132,7 +132,7 @@ function M.copy_register(register)
 end
 
 function M.copy_operator_text(text)
-	return M.copy(text)
+  return M.copy(text)
 end
 
 -------------------- SETUP ---------------------------------


### PR DESCRIPTION
This function allows to pass an argument that is going to be copied to the buffer. It allows a user to define it's own lua functions that are able to copy data through the plugin.

Example of usage:

```lua
function GetCurrentFilePath()
  local config = {}
  config.config = {
    register = 'unnamedplus',
  }
  local api = require 'socks-copypath.api'
  local path = api.copy_absolute_path(config)
  require('osc52').copy_operator_text(path)
end
```